### PR TITLE
Update patch to work with v1.4.0-1

### DIFF
--- a/Install-IntegerScaling.ps1
+++ b/Install-IntegerScaling.ps1
@@ -24,12 +24,12 @@ $Patches = @(
 				Patched = 'sc.PIXEL_SIZE={ONE:0,TWO:1,THREE:2,FOUR:3,FIVE:4,SIX:5};'
 			}
 			[PSCustomObject]@{
-				Original = 'else if(b=="pixel-size"){window.IG_GAME_SCALE=(this.values[b]||0)+1;localStorage.setItem("options.scale",window.IG_GAME_SCALE)}'
-				Patched = 'else if(b=="pixel-size"){window.IG_GAME_SCALE=(this.values[b]||0)+1;localStorage.setItem("options.scale",window.IG_GAME_SCALE);this._setDisplaySize();}'
+				Original = 'else if(a=="pixel-size"){window.IG_GAME_SCALE=(this.values[a]||0)+1;localStorage.setItem("options.scale",window.IG_GAME_SCALE)}'
+				Patched = 'else if(a=="pixel-size"){window.IG_GAME_SCALE=(this.values[a]||0)+1;localStorage.setItem("options.scale",window.IG_GAME_SCALE);this._setDisplaySize();}'
 			}
 			[PSCustomObject]@{
-				Original = 'case sc.DISPLAY_TYPE.STRETCH:o=true;a=b;b=e;f=true;break;default:a=c;b=d'
-				Patched = 'case sc.DISPLAY_TYPE.STRETCH:o=true;a=b;b=e;f=true;break;case sc.DISPLAY_TYPE.INTEGER:f=true;if(b>c*window.IG_GAME_SCALE&&e>d*window.IG_GAME_SCALE){a=c*window.IG_GAME_SCALE;b=d*window.IG_GAME_SCALE}else if(Math.floor(b/c)==0||Math.floor(e/d)==0){a=c;b=d}else{if(b/c<e/d){a=c*Math.floor(b/c);b=d*Math.floor(b/c)}else{a=c*Math.floor(e/d);b=d*Math.floor(e/d)}}break;default:a=c;b=d'
+				Original = 'case sc.DISPLAY_TYPE.STRETCH:k=true;a=b;b=i;j=true;break;default:a=c;b=d'
+				Patched = 'case sc.DISPLAY_TYPE.STRETCH:k=true;a=b;b=i;j=true;break;case sc.DISPLAY_TYPE.INTEGER:j=true;if(b>c*window.IG_GAME_SCALE&&i>d*window.IG_GAME_SCALE){a=c*window.IG_GAME_SCALE;b=d*window.IG_GAME_SCALE}else if(Math.floor(b/c)==0||Math.floor(i/d)==0){a=c;b=d}else{if(b/c<i/d){a=c*Math.floor(b/c);b=d*Math.floor(b/c)}else{a=c*Math.floor(i/d);b=d*Math.floor(i/d)}}break;default:a=c;b=d'
 			}
 		)
 		Content = $null
@@ -59,7 +59,7 @@ ForEach ($Patch in $Patches)
 	{
 		Stop-Script "One or more of the required files were not. Verify that the script is being run in the game folder."
 	} else {
-		
+
 		Write-Host "Reading file contents..."
 		$Patch.Content = Get-Content -Path $Patch.File -Raw
 
@@ -89,7 +89,7 @@ ForEach ($Patch in $Patches)
 	{
 		$Patch.Content = $Patch.Content -replace [regex]::escape($Change.Original), $Change.Patched
 	}
-	
+
 	$Patch.Content | Set-Content -Path $Patch.File
 }
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Patch to add integer-based scaling method to CrossCode through a new custom disp
 
 Why integer scaling? To prevent blur and/or shimmering that can otherwise result as a consequence as pixels are interpolated and doesn't fit evenly. See http://tanalin.com/en/articles/lossless-scaling/ for a better explanation. The idea came as a result of [this thread](https://steamcommunity.com/app/368340/discussions/0/1640915206443018918/) on the Steam Community forums, and previous requests made to add integer scaling to the game.
 
-*Confirmed working with build ID 3830405 on Steam, manifest 3613959795902897611 of depot 368341 (dated May 16, 2019 – 18:02:18 UTC). May or may not work with copies on other platforms.*
+*Confirmed working with build ID 6337146 on Steam, manifest 2547596954615951835 of depot 368349 (dated March 5, 2021 – 18:13:28 UTC). May or may not work with copies on other platforms.*
 
 
 ## Instructions
@@ -66,8 +66,8 @@ The patch changes the following code sections:
 
 * _checkSystemSettings - Added a call to _setDisplaySize() (needed to properly apply the integer ratio on launch and when changing pixel size).
 ```
-        } else if (b == "pixel-size") {
-        	window.IG_GAME_SCALE = (this.values[b] || 0) + 1;
+        } else if (a == "pixel-size") {
+        	window.IG_GAME_SCALE = (this.values[a] || 0) + 1;
         	localStorage.setItem("options.scale", window.IG_GAME_SCALE);
         	this._setDisplaySize();
         }
@@ -76,19 +76,19 @@ The patch changes the following code sections:
 * _setDisplaySize - Added a new case for the switch statement for handling integer scaling:
 ```
 case sc.DISPLAY_TYPE.INTEGER:
-	if (b > c * window.IG_GAME_SCALE && e > d * window.IG_GAME_SCALE) {
+	if (b > c * window.IG_GAME_SCALE && i > d * window.IG_GAME_SCALE) {
 		a = c * window.IG_GAME_SCALE;
 		b = d * window.IG_GAME_SCALE;
 	} else if (Math.floor(b / c) == 0 || Math.floor(e / d) == 0) {
 		a = c;
 		b = d;
 	} else {
-		if (b / c < e / d) {
+		if (b / c < i / d) {
 			a = c * Math.floor(b / c);
 			b = d * Math.floor(b / c);
 		} else {
-			a = c * Math.floor(e / d);
-			b = d * Math.floor(e / d);
+			a = c * Math.floor(i / d);
+			b = d * Math.floor(i / d);
 		}
 	}
 	break;

--- a/Uninstall-IntegerScaling.ps1
+++ b/Uninstall-IntegerScaling.ps1
@@ -24,12 +24,12 @@ $Patches = @(
 				Patched = 'sc.PIXEL_SIZE={ONE:0,TWO:1,THREE:2,FOUR:3,FIVE:4,SIX:5};'
 			}
 			[PSCustomObject]@{
-				Original = 'else if(b=="pixel-size"){window.IG_GAME_SCALE=(this.values[b]||0)+1;localStorage.setItem("options.scale",window.IG_GAME_SCALE)}'
-				Patched = 'else if(b=="pixel-size"){window.IG_GAME_SCALE=(this.values[b]||0)+1;localStorage.setItem("options.scale",window.IG_GAME_SCALE);this._setDisplaySize();}'
+				Original = 'else if(a=="pixel-size"){window.IG_GAME_SCALE=(this.values[a]||0)+1;localStorage.setItem("options.scale",window.IG_GAME_SCALE)}'
+				Patched = 'else if(a=="pixel-size"){window.IG_GAME_SCALE=(this.values[a]||0)+1;localStorage.setItem("options.scale",window.IG_GAME_SCALE);this._setDisplaySize();}'
 			}
 			[PSCustomObject]@{
-				Original = 'case sc.DISPLAY_TYPE.STRETCH:o=true;a=b;b=e;f=true;break;default:a=c;b=d'
-				Patched = 'case sc.DISPLAY_TYPE.STRETCH:o=true;a=b;b=e;f=true;break;case sc.DISPLAY_TYPE.INTEGER:f=true;if(b>c*window.IG_GAME_SCALE&&e>d*window.IG_GAME_SCALE){a=c*window.IG_GAME_SCALE;b=d*window.IG_GAME_SCALE}else if(Math.floor(b/c)==0||Math.floor(e/d)==0){a=c;b=d}else{if(b/c<e/d){a=c*Math.floor(b/c);b=d*Math.floor(b/c)}else{a=c*Math.floor(e/d);b=d*Math.floor(e/d)}}break;default:a=c;b=d'
+				Original = 'case sc.DISPLAY_TYPE.STRETCH:k=true;a=b;b=i;j=true;break;default:a=c;b=d'
+				Patched = 'case sc.DISPLAY_TYPE.STRETCH:k=true;a=b;b=i;j=true;break;case sc.DISPLAY_TYPE.INTEGER:j=true;if(b>c*window.IG_GAME_SCALE&&i>d*window.IG_GAME_SCALE){a=c*window.IG_GAME_SCALE;b=d*window.IG_GAME_SCALE}else if(Math.floor(b/c)==0||Math.floor(i/d)==0){a=c;b=d}else{if(b/c<i/d){a=c*Math.floor(b/c);b=d*Math.floor(b/c)}else{a=c*Math.floor(i/d);b=d*Math.floor(i/d)}}break;default:a=c;b=d'
 			}
 		)
 		Content = $null
@@ -59,7 +59,6 @@ ForEach ($Patch in $Patches)
 	{
 		Stop-Script "One or more of the required files were not. Verify that the script is being run in the game folder."
 	} else {
-		
 		Write-Host "Reading file contents..."
 		$Patch.Content = Get-Content -Path $Patch.File -Raw
 
@@ -71,7 +70,7 @@ ForEach ($Patch in $Patches)
 				if($MatchesFound -ne 1)
 				{
 					Stop-Script "Expected 1 match but found $MatchesFound, in file '$($Patch.File)', for line:
-					$($Change.Patched)" 
+					$($Change.Patched)"
 				}
 			}
 		} else {
@@ -89,7 +88,7 @@ ForEach ($Patch in $Patches)
 	{
 		$Patch.Content = $Patch.Content -replace [regex]::escape($Change.Patched), $Change.Original
 	}
-	
+
 	$Patch.Content | Set-Content -Path $Patch.File
 }
 


### PR DESCRIPTION
As of the latest update, the patcher no longer works due to the renaming of two variables (`b` -> `a` in the first patch and `e`->`i` as well as `f`->`j` in the second). This PR updates the patch so it works again, fixing #2.